### PR TITLE
Remove use of array_first to support Laravel versions lower than 5.4

### DIFF
--- a/src/CountryHelper.php
+++ b/src/CountryHelper.php
@@ -16,11 +16,12 @@ class CountryHelper extends Helper
     {
         $countries = $this->config->get('countries');
 
-        return array_first(
-            $countries,
-            function ($country) use ($property, $value) {
-                return array_get($country, $property) === $value;
+        foreach ($countries as $country){
+            if(array_get($country, $property) === $value){
+                return $country;
             }
-        );
+        }
+
+       return null;
     }
 }

--- a/src/CountryHelper.php
+++ b/src/CountryHelper.php
@@ -16,12 +16,12 @@ class CountryHelper extends Helper
     {
         $countries = $this->config->get('countries');
 
-        foreach ($countries as $country){
-            if(array_get($country, $property) === $value){
+        foreach ($countries as $country) {
+            if (array_get($country, $property) === $value) {
                 return $country;
             }
         }
 
-       return null;
+        return null;
     }
 }


### PR DESCRIPTION
The helper `array_first` from `illuminate` changed the signature of the callback from ($key,$value) to ($value, $key) to be able to support lower versions we changed and removed the use.