### PR TITLE
SWP-23 - Up to 6 decimals within CurrencyHelper toFormat()

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Require the package in composer:
 
 ```javascript
 "require": {
-    "pod-point/countries": "^2.0"
+    "pod-point/countries": "^3.0"
 },
 ```
 

--- a/src/CurrencyHelper.php
+++ b/src/CurrencyHelper.php
@@ -22,6 +22,10 @@ class CurrencyHelper extends LocalizedHelper
             NumberFormatter::CURRENCY
         );
 
+        // NumberFormatter will round up with 2 decimals only by default.
+        // Sometimes we can display up to 6 decimals of the monetary unit (ex: £0.106544) for energy prices.
+        $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 6);
+
         return $formatter->formatCurrency($value, $currencyCode);
     }
 

--- a/tests/CurrencyHelperTest.php
+++ b/tests/CurrencyHelperTest.php
@@ -111,7 +111,7 @@ class CurrencyHelperTest extends TestCase
     }
 
     /**
-     * Tests that it returns formatted value from cents.
+     * Tests that it returns formatted value fractional monetary values.
      */
     public function testToFormatFromInt()
     {
@@ -126,6 +126,26 @@ class CurrencyHelperTest extends TestCase
 
         $expected = '£15.50';
         $actual = $currencyHelper->toFormatFromInt('1550');
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that it returns formatted value with up to six decimals from fractional monetary values.
+     */
+    public function testToFormatCanDisplayUpToSixDecimals()
+    {
+        $config = $this->createMock(Repository::class);
+        $currencyHelper = new CurrencyHelper($config);
+        $countries = require __DIR__ . '/../src/config/countries.php';
+
+        $config->expects($this->once())
+            ->method('get')
+            ->with('countries')
+            ->willReturn($countries);
+
+        $expected = '£0.106544';
+        $actual = $currencyHelper->toFormat('0.106544');
 
         $this->assertEquals($expected, $actual);
     }


### PR DESCRIPTION
PHP NumberFormatter will round up with 2 decimals only by default.
Sometimes we can display up to 6 decimals of the monetary unit (ex: £0.106544) for energy prices.
If a regular float `19.99` with only 2 decimals is given, it will still be formatted as usual `£19.99`.