### PR TITLE
[Feature / SWP-1902]: Solve Tritium formatting display problem

### DIFF
--- a/src/CurrencyHelper.php
+++ b/src/CurrencyHelper.php
@@ -67,7 +67,7 @@ class CurrencyHelper extends LocalizedHelper
             return $formatter->formatCurrency($value, $currencyCode);
         }
 
-        return $this->toFormat($value, $currencyCode, $locale);
+        return $this->toFormatFromInt($value, $currencyCode, $locale);
     }
 
     /**

--- a/src/CurrencyHelper.php
+++ b/src/CurrencyHelper.php
@@ -54,20 +54,20 @@ class CurrencyHelper extends LocalizedHelper
      *
      * @return string
      */
-    public function toFormatIncludingMinorUnit(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
+    public function formatToMinorUnitWhenApplicable(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
     {
-        $formatter = new NumberFormatter(
-            $this->getSystemLocale($locale),
-            NumberFormatter::CURRENCY
-        );
-
         if ($value <= $this->getMinorUnitEnd($locale) && $pattern = $this->getMinorUnitPattern($locale)) {
+            $formatter = new NumberFormatter(
+                $this->getSystemLocale($locale),
+                NumberFormatter::CURRENCY
+            );
+
             $formatter->setPattern($pattern);
 
             return $formatter->formatCurrency($value, $currencyCode);
         }
 
-        return $this->toFormatFromInt($value, $currencyCode, $locale);
+        return $this->toFormat($value, $currencyCode, $locale);
     }
 
     /**

--- a/src/CurrencyHelper.php
+++ b/src/CurrencyHelper.php
@@ -61,7 +61,7 @@ class CurrencyHelper extends LocalizedHelper
             NumberFormatter::CURRENCY
         );
 
-        if ($value < $this->getMinorUnitEnd($locale) && $pattern = $this->getMinorUnitPattern($locale)) {
+        if ($value <= $this->getMinorUnitEnd($locale) && $pattern = $this->getMinorUnitPattern($locale)) {
             $formatter->setPattern($pattern);
 
             return $formatter->formatCurrency($value, $currencyCode);

--- a/src/CurrencyHelper.php
+++ b/src/CurrencyHelper.php
@@ -56,7 +56,9 @@ class CurrencyHelper extends LocalizedHelper
      */
     public function formatToMinorUnitWhenApplicable(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
     {
-        if ($value <= $this->getMinorUnitEnd($locale) && $pattern = $this->getMinorUnitPattern($locale)) {
+        $pattern = $this->getMinorUnitPattern($locale);
+
+        if ($value <= $this->getMinorUnitEnd($locale) && $pattern) {
             $formatter = new NumberFormatter(
                 $this->getSystemLocale($locale),
                 NumberFormatter::CURRENCY

--- a/src/CurrencyHelper.php
+++ b/src/CurrencyHelper.php
@@ -45,6 +45,32 @@ class CurrencyHelper extends LocalizedHelper
     }
 
     /**
+     * Transform an integer representing a decimal currency value (penny, cents...) into a monetary formatted string
+     * with the right currency symbol and the right localised format for the parameters respectively given.
+     *
+     * @param int $value
+     * @param string $currencyCode
+     * @param string $locale
+     *
+     * @return string
+     */
+    public function toFormatIncludingMinorUnit(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
+    {
+        $formatter = new NumberFormatter(
+            $this->getSystemLocale($locale),
+            NumberFormatter::CURRENCY
+        );
+
+        if ($value < $this->getMinorUnitEnd($locale) && $pattern = $this->getMinorUnitPattern($locale)) {
+            $formatter->setPattern($pattern);
+
+            return $formatter->formatCurrency($value, $currencyCode);
+        }
+
+        return $this->toFormatFromInt($value, $currencyCode, $locale);
+    }
+
+    /**
      * Return a currency symbol formatted in the right locale.
      *
      * @param string $locale

--- a/src/Facades/CurrencyHelper.php
+++ b/src/Facades/CurrencyHelper.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static string toFormat($value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  * @method static string toFormatFromInt(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
- * @method static string formatToMinorUnitWhenApplicable(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
+ * @method static string getFormatToMinorUnitWhenApplicable(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  * @method static string getSymbol(string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  */
 class CurrencyHelper extends Facade

--- a/src/Facades/CurrencyHelper.php
+++ b/src/Facades/CurrencyHelper.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static string toFormat($value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  * @method static string toFormatFromInt(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
+ * @method static string toFormatIncludingMinorUnit(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  * @method static string getSymbol(string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  */
 class CurrencyHelper extends Facade

--- a/src/Facades/CurrencyHelper.php
+++ b/src/Facades/CurrencyHelper.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static string toFormat($value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  * @method static string toFormatFromInt(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
- * @method static string toFormatIncludingMinorUnit(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
+ * @method static string formatToMinorUnitWhenApplicable(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  * @method static string getSymbol(string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  */
 class CurrencyHelper extends Facade

--- a/src/LocalizedHelper.php
+++ b/src/LocalizedHelper.php
@@ -52,7 +52,7 @@ abstract class LocalizedHelper extends Helper
     }
 
     /**
-     * Return the last minor unit from locale. (en => 99 pence)
+     * Return the last minor unit from locale. (en => 99)
      *
      * @param string $locale
      *

--- a/src/LocalizedHelper.php
+++ b/src/LocalizedHelper.php
@@ -36,4 +36,32 @@ abstract class LocalizedHelper extends Helper
 
         return $country['systemLocale'];
     }
+
+    /**
+     * Return minor unit pattern from locale. (en => #,###.###p)
+     *
+     * @param string $locale
+     *
+     * @return string|null
+     */
+    protected function getMinorUnitPattern(string $locale): ?string
+    {
+        $country = $this->countryHelper->findBy('locale', $locale);
+
+        return $country['minorUnitPattern'] ?? null;
+    }
+
+    /**
+     * Return the last minor unit from locale. (en => 99 pence)
+     *
+     * @param string $locale
+     *
+     * @return int|null
+     */
+    protected function getMinorUnitEnd(string $locale): ?int
+    {
+        $country = $this->countryHelper->findBy('locale', $locale);
+
+        return $country['minorUnitEnd'] ?? null;
+    }
 }

--- a/src/LocalizedHelper.php
+++ b/src/LocalizedHelper.php
@@ -38,7 +38,7 @@ abstract class LocalizedHelper extends Helper
     }
 
     /**
-     * Return minor unit pattern from locale. (en => #,###.###p)
+     * Return minor unit pattern from locale. (en => #.##p)
      *
      * @param string $locale
      *

--- a/src/config/countries-partial.php
+++ b/src/config/countries-partial.php
@@ -23,6 +23,8 @@ return [
         'language' => 'ENG',
         'tld' => 'com',
         'timezone' => 'Europe/London',
+        'minorUnitEnd' => 99,
+        'minorUnitPattern' => '#,###.###p'
     ],
     CountryCode::IRELAND => [
         'systemLocale' => 'en_IE.UTF-8',

--- a/src/config/countries-partial.php
+++ b/src/config/countries-partial.php
@@ -24,7 +24,7 @@ return [
         'tld' => 'com',
         'timezone' => 'Europe/London',
         'minorUnitEnd' => 99,
-        'minorUnitPattern' => '#,###.###p'
+        'minorUnitPattern' => '#.##p'
     ],
     CountryCode::IRELAND => [
         'systemLocale' => 'en_IE.UTF-8',

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -66,6 +66,6 @@ if (!function_exists('getMoneyFormatWithPence')) {
      */
     function getMoneyFormatWithPence(string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
     {
-        return CurrencyHelper::toFormatIncludingMinorUnit($currencyCode, $locale);
+        return CurrencyHelper::formatToMinorUnitWhenApplicable($currencyCode, $locale);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -54,17 +54,18 @@ if (!function_exists('getCurrencySymbol')) {
     }
 }
 
-if (!function_exists('getMoneyFormatWithPence')) {
+if (!function_exists('getFormatToMinorUnitWhenApplicable')) {
 
     /**
      * Return a currency symbol formatted in the right locale.
      *
+     * @param int $value
      * @param string $currencyCode
      * @param string $locale
      *
      * @return string
      */
-    function getMoneyFormatWithPence(string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
+    function getFormatToMinorUnitWhenApplicable(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
     {
         return CurrencyHelper::formatToMinorUnitWhenApplicable($currencyCode, $locale);
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -67,6 +67,6 @@ if (!function_exists('getFormatToMinorUnitWhenApplicable')) {
      */
     function getFormatToMinorUnitWhenApplicable(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
     {
-        return CurrencyHelper::formatToMinorUnitWhenApplicable($currencyCode, $locale);
+        return CurrencyHelper::formatToMinorUnitWhenApplicable($value, $currencyCode, $locale);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -53,3 +53,19 @@ if (!function_exists('getCurrencySymbol')) {
         return CurrencyHelper::getSymbol($currencyCode, $locale);
     }
 }
+
+if (!function_exists('getMoneyFormatWithPence')) {
+
+    /**
+     * Return a currency symbol formatted in the right locale.
+     *
+     * @param string $currencyCode
+     * @param string $locale
+     *
+     * @return string
+     */
+    function getMoneyFormatWithPence(string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
+    {
+        return CurrencyHelper::toFormatIncludingMinorUnit($currencyCode, $locale);
+    }
+}

--- a/tests/Unit/CurrencyHelperTest.php
+++ b/tests/Unit/CurrencyHelperTest.php
@@ -130,7 +130,7 @@ class CurrencyHelperTest extends TestCase
         $this->loadConfiguration()->loadServiceProvider();
 
         $expected = '20p';
-        $actual = (new CurrencyHelper($this->app->config))->toFormatIncludingMinorUnit(20);
+        $actual = (new CurrencyHelper($this->app->config))->formatToMinorUnitWhenApplicable(20);
 
         $this->assertEquals($expected, $actual);
     }
@@ -144,7 +144,7 @@ class CurrencyHelperTest extends TestCase
 
         // Expected empty string is the current behaviour when using existing methods.
         $expected = '';
-        $actual = (new CurrencyHelper($this->app->config))->toFormatIncludingMinorUnit(20, CountryCode::IRELAND, 'ie');
+        $actual = (new CurrencyHelper($this->app->config))->formatToMinorUnitWhenApplicable(20, CountryCode::IRELAND, 'ie');
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Unit/CurrencyHelperTest.php
+++ b/tests/Unit/CurrencyHelperTest.php
@@ -142,7 +142,7 @@ class CurrencyHelperTest extends TestCase
     {
         $this->loadConfiguration()->loadServiceProvider();
 
-        // Expected empty string is the current behaviour for existing methods.
+        // Expected empty string is the current behaviour when using existing methods.
         $expected = '';
         $actual = (new CurrencyHelper($this->app->config))->toFormatIncludingMinorUnit(20, CountryCode::IRELAND, 'ie');
 

--- a/tests/Unit/CurrencyHelperTest.php
+++ b/tests/Unit/CurrencyHelperTest.php
@@ -79,6 +79,54 @@ class CurrencyHelperTest extends TestCase
     }
 
     /**
+     * Data provider for test.
+     *
+     * @return array
+     */
+    public function providerTestFormatToMinorUnitWhenApplicable()
+    {
+        return [
+            'Pound Sterling happy path' => [
+                '20',
+                CurrencyCode::POUND_STERLING,
+                'en',
+                '20p',
+            ],
+            'Pound Sterling negative value' => [
+                '-20',
+                CurrencyCode::POUND_STERLING,
+                'en',
+                '-20p',
+            ],
+            'Pound Sterling high value' => [
+                '20000000',
+                CurrencyCode::POUND_STERLING,
+                'en',
+                '£200,000.00',
+            ],
+            'Pound Sterling within minor unit end' => [
+                '75',
+                CurrencyCode::POUND_STERLING,
+                'en',
+                '75p',
+            ],
+            'European Euro' => [
+                '20',
+                CurrencyCode::EURO,
+                'ie',
+                '€0.20',
+            ],
+            'European Euro high value' => [
+                '20000000',
+                CurrencyCode::EURO,
+                'ie',
+                '€200,000.00',
+            ],
+        ];
+    }
+
+
+    /**
      * Tests that it returns a currency symbol.
      *
      * @dataProvider providerTestGetSymbol
@@ -124,26 +172,18 @@ class CurrencyHelperTest extends TestCase
 
     /**
      * Tests that it returns formatted value with minor unit symbol from fractional monetary values.
+     *
+     * @dataProvider  providerTestFormatToMinorUnitWhenApplicable
+     * @param int $value
+     * @param string $currencyCode
+     * @param string $locale
+     * @param string $expected
      */
-    public function testToFormatCanDisplayMinorUnitSymbol()
+    public function testFormatToMinorUnitWhenApplicablel(int $value, string $currencyCode, string $locale, string $expected)
     {
         $this->loadConfiguration()->loadServiceProvider();
 
-        $expected = '20p';
-        $actual = (new CurrencyHelper($this->app->config))->formatToMinorUnitWhenApplicable(20);
-
-        $this->assertEquals($expected, $actual);
-    }
-
-    /**
-     * Tests that it returns formatted value without minor unit symbol from fractional monetary values.
-     */
-    public function testToFormatCanDisplayMinorUnitSymbolWithoutPattern()
-    {
-        $this->loadConfiguration()->loadServiceProvider();
-
-        $expected = '€0.20';
-        $actual = (new CurrencyHelper($this->app->config))->formatToMinorUnitWhenApplicable(20, CurrencyCode::EURO, 'ie');
+        $actual = (new CurrencyHelper($this->app->config))->formatToMinorUnitWhenApplicable($value, $currencyCode, $locale);
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Unit/CurrencyHelperTest.php
+++ b/tests/Unit/CurrencyHelperTest.php
@@ -142,6 +142,7 @@ class CurrencyHelperTest extends TestCase
     {
         $this->loadConfiguration()->loadServiceProvider();
 
+        // Expected empty string is the current behaviour for existing methods.
         $expected = '';
         $actual = (new CurrencyHelper($this->app->config))->toFormatIncludingMinorUnit(20, CountryCode::IRELAND, 'ie');
 

--- a/tests/Unit/CurrencyHelperTest.php
+++ b/tests/Unit/CurrencyHelperTest.php
@@ -142,7 +142,7 @@ class CurrencyHelperTest extends TestCase
     {
         $this->loadConfiguration()->loadServiceProvider();
 
-        $expected = '€20.00';
+        $expected = '€0.20';
         $actual = (new CurrencyHelper($this->app->config))->formatToMinorUnitWhenApplicable(20, CurrencyCode::EURO, 'ie');
 
         $this->assertEquals($expected, $actual);

--- a/tests/Unit/CurrencyHelperTest.php
+++ b/tests/Unit/CurrencyHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace PodPoint\I18n\Tests\Unit;
 
+use PodPoint\I18n\CountryCode;
 use PodPoint\I18n\CurrencyCode;
 use PodPoint\I18n\CurrencyHelper;
 use PodPoint\I18n\Tests\TestCase;
@@ -117,6 +118,32 @@ class CurrencyHelperTest extends TestCase
 
         $expected = '£0.106544';
         $actual = (new CurrencyHelper($this->app->config))->toFormat('0.106544');
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that it returns formatted value with minor unit symbol from fractional monetary values.
+     */
+    public function testToFormatCanDisplayMinorUnitSymbol()
+    {
+        $this->loadConfiguration()->loadServiceProvider();
+
+        $expected = '20p';
+        $actual = (new CurrencyHelper($this->app->config))->toFormatIncludingMinorUnit(20);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that it returns formatted value without minor unit symbol from fractional monetary values.
+     */
+    public function testToFormatCanDisplayMinorUnitSymbolWithoutPattern()
+    {
+        $this->loadConfiguration()->loadServiceProvider();
+
+        $expected = '';
+        $actual = (new CurrencyHelper($this->app->config))->toFormatIncludingMinorUnit(20, CountryCode::IRELAND, 'ie');
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Unit/CurrencyHelperTest.php
+++ b/tests/Unit/CurrencyHelperTest.php
@@ -142,9 +142,8 @@ class CurrencyHelperTest extends TestCase
     {
         $this->loadConfiguration()->loadServiceProvider();
 
-        // Expected empty string is the current behaviour when using existing methods.
-        $expected = '';
-        $actual = (new CurrencyHelper($this->app->config))->formatToMinorUnitWhenApplicable(20, CountryCode::IRELAND, 'ie');
+        $expected = '€20.00';
+        $actual = (new CurrencyHelper($this->app->config))->formatToMinorUnitWhenApplicable(20, CurrencyCode::EURO, 'ie');
 
         $this->assertEquals($expected, $actual);
     }


### PR DESCRIPTION
Formats currency. Previously, we didn't have anything that would add pence, if the price is less than 100. This functionality adds in if price is < £1 then its 60p, depending on which country is configured



![Screenshot 2020-10-06 at 09 17 07](https://user-images.githubusercontent.com/7601026/95178473-60d65180-07b7-11eb-9570-b9ca5e05c01b.png)
