### PR TITLE
Feature - SWP-2834 - Upgrade from 5.8 -> 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: php
 
 php:
-  - '7.1'
+  - '7.2'
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,3 @@ before_script:
 
 script:
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-
-after_success:
-  - bash <(curl -s build/logs/ https://codecov.io/bash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes will be documented in this file.
+
+## 4.0.0 - 2021-04-29
+
+Major release to support PHP 7.2 and Laravel 6.x
+- Illuminate packages 5.* -> 6.*
+- PHPUnit 7.x -> 8.x
+- Guzzle 6.x -> 7.x
+- Removal of satooshi/php-coveralls in favour of php-coveralls/php-coveralls
+
+#### Breaking changes:
+- This package can no longer support PHP7.1 - if using PHP7.1 please use version 3.*.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Internationalisation Package
 
-[![Build Status](https://travis-ci.org/Pod-Point/countries.svg?branch=master)](https://travis-ci.org/Pod-Point/countries) [![codecov](https://codecov.io/gh/Pod-Point/countries/branch/master/graph/badge.svg?token=kG5ptGaEFs)](https://codecov.io/gh/Pod-Point/countries) [![Packagist](https://img.shields.io/packagist/v/Pod-Point/countries.svg)](https://packagist.org/packages/pod-point/countries)
+[![Build Status](https://travis-ci.org/Pod-Point/countries.svg?branch=master)](https://travis-ci.org/Pod-Point/countries) [![Packagist](https://img.shields.io/packagist/v/Pod-Point/countries.svg)](https://packagist.org/packages/pod-point/countries)
 
 This package provides Laravel and Lumen applications internationalisation features:
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,17 @@ The countries are indexed using their uppercase ISO codes (alpha2/cca2).
 
 Require the package in composer:
 
+For Laravel 5.* and PHP <= 7.1
 ```javascript
 "require": {
     "pod-point/countries": "^3.0"
+},
+```
+
+For Laravel 6.* and PHP >= 7.2
+```javascript
+"require": {
+    "pod-point/countries": "^4.0"
 },
 ```
 
@@ -35,3 +43,7 @@ If you're using Lumen, add the following line to your `bootstrap/app.php` file:
 ```php
 $app->register(PodPoint\I18n\Providers\CountriesServiceProvider::class);
 ```
+
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "illuminate/support": "^6.0",
         "illuminate/view": "^6.0",
         "league/iso3166": "^2.1",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.0",
         "mpociot/vat-calculator": "^2.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "satooshi/php-coveralls": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^8.5"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "mpociot/vat-calculator": "^2.4"
     },
     "require-dev": {
-        "satooshi/php-coveralls": "^1.0",
+        "php-coveralls/php-coveralls": "^2.0",
         "phpunit/phpunit": "^8.5"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "A package of useful components for internationalisation in Laravel applications.",
     "type": "library",
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "ext-intl": "*",
-        "illuminate/config": "5.*",
-        "illuminate/support": "5.*",
-        "illuminate/view": "5.*",
+        "illuminate/config": "^6.0",
+        "illuminate/support": "^6.0",
+        "illuminate/view": "^6.0",
         "league/iso3166": "^2.1",
         "guzzlehttp/guzzle": "^6.3",
         "mpociot/vat-calculator": "^2.4"

--- a/src/Currency/OpenExchangeRates/Service.php
+++ b/src/Currency/OpenExchangeRates/Service.php
@@ -3,6 +3,7 @@
 namespace PodPoint\I18n\Currency\OpenExchangeRates;
 
 use Carbon\Carbon;
+use GuzzleHttp\Utils;
 use PodPoint\I18n\CurrencyCode;
 use Illuminate\Support\Collection;
 use PodPoint\I18n\Currency\ExchangeRate;
@@ -60,7 +61,7 @@ class Service implements CurrencyService
         $query = http_build_query($params);
 
         $response = $this->client->get("{$endpoint}?{$query}");
-        $json = \GuzzleHttp\json_decode($response->getBody()->getContents(), true);
+        $json = Utils::jsonDecode($response->getBody()->getContents(), true);
         $timestamp = Carbon::createFromTimestamp($json['timestamp']);
         $rates = $json['rates'];
 

--- a/src/ViewComposers/CountryCodeViewComposer.php
+++ b/src/ViewComposers/CountryCodeViewComposer.php
@@ -2,6 +2,7 @@
 
 namespace PodPoint\I18n\ViewComposers;
 
+use GuzzleHttp\Utils;
 use Illuminate\View\View;
 use Illuminate\Config\Repository;
 use PodPoint\I18n\CountryCode;
@@ -91,7 +92,7 @@ class CountryCodeViewComposer
             ],
         ];
 
-        return \GuzzleHttp\json_encode($countryGroups);
+        return Utils::jsonEncode($countryGroups);
     }
 
     /**

--- a/tests/TaxRateTest.php
+++ b/tests/TaxRateTest.php
@@ -17,7 +17,7 @@ class TaxRateTest extends TestCase
     /**
      * @inheritDoc
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TaxRateTest.php
+++ b/tests/TaxRateTest.php
@@ -53,10 +53,10 @@ class TaxRateTest extends TestCase
      *
      * @dataProvider supportedCountriesTaxRateDataProvider
      *
-     * @param CountryCode $countryCode
+     * @param string $countryCode
      * @param float $currentVatRate
      */
-    public function testWeCanGetTaxRateForSupportedCountries($countryCode, $currentVatRate)
+    public function testWeCanGetTaxRateForSupportedCountries(string $countryCode, float $currentVatRate)
     {
         $this->assertEquals($currentVatRate, $this->taxRate->get($countryCode));
    }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,7 +21,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * Set up tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/CountryHelperTest.php
+++ b/tests/Unit/CountryHelperTest.php
@@ -45,7 +45,7 @@ class CountryHelperTest extends TestCase
 
         $actual = (new CountryHelper($this->app->config))->getCountryCodeFromLocale('en');
 
-        $this->assertEquals($actual, 'GB');
+        $this->assertEquals('GB', $actual);
     }
 
     /**

--- a/tests/Unit/CurrencyHelperTest.php
+++ b/tests/Unit/CurrencyHelperTest.php
@@ -86,37 +86,37 @@ class CurrencyHelperTest extends TestCase
     {
         return [
             'Pound Sterling happy path' => [
-                '20',
+                20,
                 CurrencyCode::POUND_STERLING,
                 'en',
                 '20p',
             ],
             'Pound Sterling negative value' => [
-                '-20',
+                -20,
                 CurrencyCode::POUND_STERLING,
                 'en',
                 '-20p',
             ],
             'Pound Sterling high value' => [
-                '20000000',
+                20000000,
                 CurrencyCode::POUND_STERLING,
                 'en',
                 '£200,000.00',
             ],
             'Pound Sterling within minor unit end' => [
-                '75',
+                75,
                 CurrencyCode::POUND_STERLING,
                 'en',
                 '75p',
             ],
             'European Euro' => [
-                '20',
+                20,
                 CurrencyCode::EURO,
                 'ie',
                 '€0.20',
             ],
             'European Euro high value' => [
-                '20000000',
+                20000000,
                 CurrencyCode::EURO,
                 'ie',
                 '€200,000.00',
@@ -239,7 +239,7 @@ class CurrencyHelperTest extends TestCase
      * @param string $locale
      * @param string $expected
      */
-    public function testFormatToMinorUnitWhenApplicablel(int $value, string $currencyCode, string $locale, string $expected)
+    public function testFormatToMinorUnitWhenApplicable(int $value, string $currencyCode, string $locale, string $expected)
     {
         $this->loadConfiguration()->loadServiceProvider();
 

--- a/tests/Unit/CurrencyServiceTest.php
+++ b/tests/Unit/CurrencyServiceTest.php
@@ -3,6 +3,7 @@
 namespace PodPoint\I18n\Tests\Unit;
 
 use Carbon\Carbon;
+use GuzzleHttp\Utils;
 use GuzzleHttp\Psr7\Response;
 use PodPoint\I18n\Tests\TestCase;
 use PodPoint\I18n\Currency\ExchangeRate;
@@ -84,11 +85,9 @@ class CurrencyServiceTest extends TestCase
             ->willReturn($appId);
 
         $this->mockClient->expects($this->once())
-            ->method('__call')
-            ->with('get', [
-                "latest.json?{$query}",
-            ])
-            ->willReturn(new Response(200, [], \GuzzleHttp\json_encode([
+            ->method('get')
+            ->with("latest.json?{$query}")
+            ->willReturn(new Response(200, [], Utils::jsonEncode([
                 'timestamp' => $timestamp->timestamp,
                 'rates' => [
                     'NOK' => $rate,
@@ -132,11 +131,9 @@ class CurrencyServiceTest extends TestCase
             ->willReturn($appId);
 
         $this->mockClient->expects($this->once())
-            ->method('__call')
-            ->with('get', [
-                "historical/{$timestamp->format('Y-m-d')}.json?{$query}",
-            ])
-            ->willReturn(new Response(200, [], \GuzzleHttp\json_encode([
+            ->method('get')
+            ->with("historical/{$timestamp->format('Y-m-d')}.json?{$query}")
+            ->willReturn(new Response(200, [], Utils::jsonEncode([
                 'timestamp' => $timestamp->timestamp,
                 'rates' => [
                     'NOK' => $rate,

--- a/tests/Unit/CurrencyServiceTest.php
+++ b/tests/Unit/CurrencyServiceTest.php
@@ -48,7 +48,7 @@ class CurrencyServiceTest extends TestCase
     /**
      * Creates mocked cache, config and OpenExchangeRates client & service instances.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Providers/CountriesServiceProviderTest.php
+++ b/tests/Unit/Providers/CountriesServiceProviderTest.php
@@ -3,10 +3,8 @@
 namespace PodPoint\I18n\Tests\Unit\Providers;
 
 use PodPoint\I18n\CountryCode;
-use Illuminate\Config\Repository;
 use PodPoint\I18n\Tests\TestCase;
 use PodPoint\I18n\Providers\CountriesServiceProvider;
-use PodPoint\I18n\CurrencyHelper;
 
 class CountriesServiceProviderTest extends TestCase
 {

--- a/tests/Unit/ViewComposers/CountryCodeViewComposerTest.php
+++ b/tests/Unit/ViewComposers/CountryCodeViewComposerTest.php
@@ -20,7 +20,7 @@ class CountryCodeViewComposerTest extends TestCase
         /** @var View|\PHPUnit_Framework_MockObject_MockObject $viewMock */
         $viewMock = $this->getMockBuilder(View::class)
             ->disableOriginalConstructor()
-            ->setMethods(['with'])
+            ->onlyMethods(['with'])
             ->getMock();
 
         $viewMock->expects($this->once())

--- a/tests/Unit/ViewComposers/CountryLocaleViewComposerTest.php
+++ b/tests/Unit/ViewComposers/CountryLocaleViewComposerTest.php
@@ -21,7 +21,7 @@ class CountryLocaleViewComposerTest extends TestCase
         /** @var View|\PHPUnit_Framework_MockObject_MockObject $viewMock */
         $viewMock = $this->getMockBuilder(View::class)
             ->disableOriginalConstructor()
-            ->setMethods(['with'])
+            ->onlyMethods(['with'])
             ->getMock();
 
         $viewMock->expects($this->once())


### PR DESCRIPTION
Version Changes:
- PHP version 7.1 -> 7.2
- Illuminate packages 5.* -> 6.*
- PHPunit 7.5 -> 8.5
- Travis php version - 7.1 -> 7.2
- satooshi/php-coveralls -> php-coveralls/php-coveralls
- Guzzle 6.3 -> 7.3

Code Changes:
- setUp function needs :void to inherit from the phpunit base setUp function in 8.5.
- PHPunit setMethods is depreciated. I have replaced it with onlyMethods.
- Guzzle jsonDecode is now moved to Utils::jsonDecode.
- Thanks to PHPunit 8.5 we can now check the type of parameters passed to functions and we were sending string not int.
- get is now an actual Guzzle method so __call is no longer needed in the mock. 

Minor:
- Remove codecov bash uploader.
- Remove unnecessary imports.
- Some extra type hinting.