### PR TITLE
[SWP-2788] Introduce memoization for efficiency during use on mass

### DIFF
--- a/src/CountryHelper.php
+++ b/src/CountryHelper.php
@@ -5,16 +5,28 @@ namespace PodPoint\I18n;
 class CountryHelper extends Helper
 {
     /**
+     * Recent lookup results by `property-value`.
+     *
+     * @var array
+     */
+    protected $results = [];
+
+    /**
      * Returns the first country matching the given property/value pair.
      *
      * @param string $property
      * @param mixed $value
-     *
      * @return array|null
      */
     public function findBy(string $property, $value): ?array
     {
-        return collect($this->config->get('countries'))
+        $key = $this->generateResultsKey($property, $value);
+
+        if ($this->results[$key] ?? false) {
+            return $this->results[$key];
+        }
+
+        return $this->results[$key] = collect($this->config->get('countries'))
             ->where($property, $value)
             ->first();
     }
@@ -43,5 +55,17 @@ class CountryHelper extends Helper
                 return isset($item['locale']) && $item['locale'] === $locale;
             });
         return $code ? $code : null;
+    }
+
+    /**
+     * Generate a string formed of the property and value for the results cache.
+     *
+     * @param string $property
+     * @param string $value
+     * @return string
+     */
+    protected function generateResultsKey(string $property, string $value): string
+    {
+        return "${property}-{$value}";
     }
 }

--- a/src/CurrencyHelper.php
+++ b/src/CurrencyHelper.php
@@ -7,6 +7,13 @@ use NumberFormatter;
 class CurrencyHelper extends LocalizedHelper
 {
     /**
+     * Number Formatters created per locale.
+     *
+     * @var array
+     */
+    protected $localizedFormatters = [];
+
+    /**
      * Return a value in the given currency formatted for the given locale.
      *
      * @param float|int $value
@@ -21,10 +28,7 @@ class CurrencyHelper extends LocalizedHelper
         string $currencyCode = CurrencyCode::POUND_STERLING,
         string $locale = 'en'
     ): string {
-        $formatter = new NumberFormatter(
-            $this->getSystemLocale($locale),
-            NumberFormatter::CURRENCY
-        );
+        $formatter = $this->getFormatter($locale);
 
         /*
          * NumberFormatter will round up with 2 decimals only by default.
@@ -127,5 +131,32 @@ class CurrencyHelper extends LocalizedHelper
         }
 
         return $formatter->formatCurrency($value, $currencyCode);
+    }
+
+    /**
+     * Get an instance of a localized Formatter.
+     *
+     * @param string $locale
+     * @return NumberFormatter
+     */
+    protected function getFormatter(string $locale): NumberFormatter
+    {
+        return $this->localizedFormatters[$locale]
+            ?? $this->setFormatter(
+                $locale,
+                new NumberFormatter($this->getSystemLocale($locale), NumberFormatter::CURRENCY)
+            );
+    }
+
+    /**
+     * Set an instance of a localized Formatter.
+     *
+     * @param string $locale
+     * @param NumberFormatter $formatter
+     * @return NumberFormatter
+     */
+    public function setFormatter(string $locale, NumberFormatter $formatter): NumberFormatter
+    {
+        return $this->localizedFormatters[$locale] = $formatter;
     }
 }


### PR DESCRIPTION
*Changes*
- Introduced a history for finds in the `CountryHelper` so that we don't perform the same lookup many times
- Introduced a caching layer for NumberFormatters used in the CurrencyHelper to avoid creating many unnecessary instances when used on mass