### PR TITLE
[5.x] Fix memoization logic and getSymbol method

### DIFF
--- a/src/CountriesServiceProvider.php
+++ b/src/CountriesServiceProvider.php
@@ -81,8 +81,7 @@ class CountriesServiceProvider extends ServiceProvider
     /**
      * Adds ISO country information to our existing country configuration.
      *
-     * @param Collection $countries
-     *
+     * @param  Collection  $countries
      * @return Collection
      */
     protected function addIsoInfoToCountryConfig(Collection $countries): Collection
@@ -96,9 +95,8 @@ class CountriesServiceProvider extends ServiceProvider
      * Adds miscellaneous country information, like the Laravel locale for each country for example,
      * to our existing country configuration.
      *
-     * @param Collection $countries
-     * @param Collection $partialCountries
-     *
+     * @param  Collection  $countries
+     * @param  Collection  $partialCountries
      * @return Collection
      */
     protected function addPartialInfoToCountryConfig(Collection $countries, Collection $partialCountries): Collection

--- a/src/CountryHelper.php
+++ b/src/CountryHelper.php
@@ -14,9 +14,8 @@ class CountryHelper extends Helper
     /**
      * Returns the first country matching the given property/value pair.
      *
-     * @param string $property
-     * @param mixed $value
-     *
+     * @param  string  $property
+     * @param  mixed  $value
      * @return array|null
      */
     public function findBy(string $property, $value): ?array
@@ -35,7 +34,7 @@ class CountryHelper extends Helper
     /**
      * Returns the first country matching the given locale.
      *
-     * @param string $locale
+     * @param  string  $locale
      * @return array|null
      */
     public function findByLocale(string $locale): ?array
@@ -46,7 +45,7 @@ class CountryHelper extends Helper
     /**
      * Returns the country code matching the given locale.
      *
-     * @param string $locale
+     * @param  string  $locale
      * @return string|null
      */
     public function getCountryCodeFromLocale(string $locale): ?string
@@ -62,8 +61,8 @@ class CountryHelper extends Helper
     /**
      * Generate a string formed of the property and value for the results cache.
      *
-     * @param string $property
-     * @param string $value
+     * @param  string  $property
+     * @param  string  $value
      * @return string
      */
     protected function generateResultsKey(string $property, string $value): string

--- a/src/Currency/Cache/Service.php
+++ b/src/Currency/Cache/Service.php
@@ -23,8 +23,8 @@ class Service implements CurrencyService
     private $service;
 
     /**
-     * @param Cache $cache
-     * @param ServiceInterface $service
+     * @param  Cache  $cache
+     * @param  ServiceInterface  $service
      */
     public function __construct(Cache $cache, ServiceInterface $service)
     {
@@ -35,11 +35,11 @@ class Service implements CurrencyService
     /**
      * Fetches the exchange rates from another service if they don't already exist in cache.
      *
-     * @param string $base
-     * @param string[] $currencies
-     * @param Carbon|null $timestamp
-     *
+     * @param  string  $base
+     * @param  string[]  $currencies
+     * @param  Carbon|null  $timestamp
      * @return Collection|ExchangeRate[]
+     *
      * @throws \Psr\SimpleCache\InvalidArgumentException
      */
     public function getExchangeRates(string $base = CurrencyCode::POUND_STERLING, array $currencies = [], ?Carbon $timestamp = null): Collection
@@ -80,11 +80,11 @@ class Service implements CurrencyService
     /**
      * Builds the key used to access/store this rate in cache.
      *
-     * @param string $base
-     * @param string $currency
-     * @param Carbon $timestamp
-     *
+     * @param  string  $base
+     * @param  string  $currency
+     * @param  Carbon  $timestamp
      * @return string
+     *
      * @throws \Psr\SimpleCache\InvalidArgumentException
      */
     private function getCacheKey(string $base, string $currency, Carbon $timestamp): string

--- a/src/Currency/ExchangeRate.php
+++ b/src/Currency/ExchangeRate.php
@@ -37,7 +37,7 @@ class ExchangeRate
     public $timestamp;
 
     /**
-     * @param array $attributes
+     * @param  array  $attributes
      */
     public function __construct(array $attributes = [])
     {

--- a/src/Currency/OpenExchangeRates/Client.php
+++ b/src/Currency/OpenExchangeRates/Client.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Str;
 class Client extends \GuzzleHttp\Client
 {
     /**
-     * @param Repository $configRepository
-     * @param array $config
+     * @param  Repository  $configRepository
+     * @param  array  $config
      */
     public function __construct(Repository $configRepository, array $config = [])
     {

--- a/src/Currency/OpenExchangeRates/Service.php
+++ b/src/Currency/OpenExchangeRates/Service.php
@@ -23,8 +23,8 @@ class Service implements CurrencyService
     private $client;
 
     /**
-     * @param Config $config
-     * @param Client $client
+     * @param  Config  $config
+     * @param  Client  $client
      */
     public function __construct(Config $config, Client $client)
     {
@@ -35,10 +35,9 @@ class Service implements CurrencyService
     /**
      * Fetches the exchange rates from the OpenExchangeRates API.
      *
-     * @param string $base
-     * @param string[] $currencies
-     * @param Carbon|null $timestamp
-     *
+     * @param  string  $base
+     * @param  string[]  $currencies
+     * @param  Carbon|null  $timestamp
      * @return Collection|ExchangeRate[]
      */
     public function getExchangeRates(string $base = CurrencyCode::POUND_STERLING, array $currencies = [], ?Carbon $timestamp = null): Collection

--- a/src/Currency/Service.php
+++ b/src/Currency/Service.php
@@ -13,10 +13,9 @@ interface Service
      * Passing an array of currencies will restrict the set of results to only the given currencies.
      * Passing a timestamp will retrieve the rates from that given date (& time if possible).
      *
-     * @param string $base
-     * @param string[] $currencies
-     * @param Carbon|null $timestamp
-     *
+     * @param  string  $base
+     * @param  string[]  $currencies
+     * @param  Carbon|null  $timestamp
      * @return Collection|ExchangeRate[]
      */
     public function getExchangeRates(string $base = CurrencyCode::POUND_STERLING, array $currencies = [], ?Carbon $timestamp = null): Collection;

--- a/src/CurrencyHelper.php
+++ b/src/CurrencyHelper.php
@@ -16,9 +16,9 @@ class CurrencyHelper extends LocalizedHelper
     /**
      * Return a value in the given currency formatted for the given locale.
      *
-     * @param float|int $value
-     * @param string $currencyCode
-     * @param string $locale
+     * @param  float|int  $value
+     * @param  string  $currencyCode
+     * @param  string  $locale
      * @return string
      *
      * @deprecated toStandardFormat should be used.

--- a/src/CurrencyHelper.php
+++ b/src/CurrencyHelper.php
@@ -7,11 +7,11 @@ use NumberFormatter;
 class CurrencyHelper extends LocalizedHelper
 {
     /**
-     * Number Formatters created per locale.
+     * Cached formatters.
      *
      * @var array
      */
-    protected $localizedFormatters = [];
+    protected $cachedFormatters = [];
 
     /**
      * Return a value in the given currency formatted for the given locale.
@@ -28,25 +28,18 @@ class CurrencyHelper extends LocalizedHelper
         string $currencyCode = CurrencyCode::POUND_STERLING,
         string $locale = 'en'
     ): string {
-        $formatter = $this->getFormatter($locale);
-
-        /*
-         * NumberFormatter will round up with 2 decimals only by default.
-         * Sometimes we can display up to 6 decimals of the monetary unit (ex: £0.106544) for energy prices.
-         */
-        $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 6);
-
-        return $formatter->formatCurrency($value, $currencyCode);
+        return $this
+            ->getDefaultFormatter($locale)
+            ->formatCurrency($value, $currencyCode);
     }
 
     /**
      * Transform an integer representing a decimal currency value (penny, cents...) into a monetary formatted string
      * with the right currency symbol and the right localised format for the parameters respectively given.
      *
-     * @param int $value
-     * @param string $currencyCode
-     * @param string $locale
-     *
+     * @param  int  $value
+     * @param  string  $currencyCode
+     * @param  string  $locale
      * @return string
      */
     public function toFormatFromInt(
@@ -61,10 +54,9 @@ class CurrencyHelper extends LocalizedHelper
      * Transform an integer representing a decimal currency value (penny, cents...) into a monetary formatted string
      * with the right currency symbol and the right localised format for the parameters respectively given.
      *
-     * @param int $value
-     * @param string $currencyCode
-     * @param string $locale
-     *
+     * @param  int  $value
+     * @param  string  $currencyCode
+     * @param  string  $locale
      * @return string
      */
     public function formatToMinorUnitWhenApplicable(
@@ -75,11 +67,9 @@ class CurrencyHelper extends LocalizedHelper
         $pattern = $this->getMinorUnitPattern($locale);
 
         if ($value <= $this->getMinorUnitEnd($locale) && $pattern) {
-            $formatter = $this->getFormatter($locale);
-
-            $formatter->setPattern($pattern);
-
-            return $formatter->formatCurrency($value, $currencyCode);
+            return $this
+                ->getPatternedFormatter($locale, $pattern)
+                ->formatCurrency($value, $currencyCode);
         }
 
         return $this->toFormatFromInt($value, $currencyCode, $locale);
@@ -88,69 +78,162 @@ class CurrencyHelper extends LocalizedHelper
     /**
      * Return a currency symbol formatted in the right locale.
      *
-     * @param string $locale
-     * @param string $currencyCode
-     *
+     * @param  string  $locale
+     * @param  string  $currencyCode
      * @return string
      */
     public function getSymbol(string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
     {
-        $formatter = $this->getFormatter($locale);
-
-        return $formatter->getSymbol(NumberFormatter::CURRENCY_SYMBOL);
+        return $this
+            ->getSymbolFormatter($locale, $currencyCode)
+            ->getSymbol(NumberFormatter::CURRENCY_SYMBOL);
     }
 
     /**
      * Return a value in the given currency format for the given currency code and locale.
      *
-     * @param float $value
-     * @param string $currencyCode
-     * @param string $locale
-     * @param int|null $precision Number of decimals to show. If null is given, it will take the default currency
-     * precision
-     *
+     * @param  float  $value
+     * @param  string  $currencyCode
+     * @param  string  $locale
+     * @param  int|null  $precision  Number of decimals to show. If null is given, it will take the default currency
+     *                               precision
      * @return string
      */
     public function toStandardFormat(
         float $value,
-        $currencyCode = CurrencyCode::POUND_STERLING,
+        string $currencyCode = CurrencyCode::POUND_STERLING,
         string $locale = 'en',
-        $precision = null
+        int $precision = null
     ): string {
-        $formatter = $this->getFormatter($locale);
+        return $this
+            ->getFixedPrecisionFormatter($locale, $precision)
+            ->formatCurrency($value, $currencyCode);
+    }
 
-        if (is_int($precision)) {
-            $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $precision);
-            $formatter->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $precision);
+    /**
+     * Get the formatter cache key.
+     *
+     * @param  array  $params
+     * @return string
+     */
+    protected function getFormatterCacheKey(array $params): string
+    {
+        return hash('sha256', serialize($params));
+    }
+
+    /**
+     * Gets a formatter or creates and returns it if not already.
+     *
+     * @param  string  $key
+     * @param  callable  $createHandler
+     * @return NumberFormatter
+     */
+    protected function getFormatter(string $key, callable $createHandler): NumberFormatter
+    {
+        if (array_key_exists($key, $this->cachedFormatters)) {
+            return $this->cachedFormatters[$key];
         }
 
-        return $formatter->formatCurrency($value, $currencyCode);
+        return $this->cachedFormatters[$key] = $createHandler();
     }
 
     /**
-     * Get an instance of a localized Formatter.
+     * Create the default formatter for the given locale.
      *
-     * @param string $locale
+     * @param  string  $locale
      * @return NumberFormatter
      */
-    protected function getFormatter(string $locale): NumberFormatter
+    protected function getDefaultFormatter(string $locale): NumberFormatter
     {
-        return $this->localizedFormatters[$locale]
-            ?? $this->setFormatter(
-                $locale,
-                new NumberFormatter($this->getSystemLocale($locale), NumberFormatter::CURRENCY)
-            );
+        return $this->getFormatter(
+            $this->getFormatterCacheKey(func_get_args()),
+            function () use ($locale) {
+                $formatter = $this->getBaseFormatter($this->getSystemLocale($locale));
+
+                /*
+                 * NumberFormatter will round up with 2 decimals only by default.
+                 * Sometimes we can display up to 6 decimals of the monetary unit (ex: £0.106544) for energy prices.
+                 */
+                $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 6);
+
+                return $formatter;
+            }
+        );
     }
 
     /**
-     * Set an instance of a localized Formatter.
+     * Create a basic number formatter for the given locale in the given style.
      *
-     * @param string $locale
-     * @param NumberFormatter $formatter
+     * @param  string  $locale
+     * @param  int|null  $style
      * @return NumberFormatter
      */
-    public function setFormatter(string $locale, NumberFormatter $formatter): NumberFormatter
+    protected function getBaseFormatter(string $locale, ?int $style = null): NumberFormatter
     {
-        return $this->localizedFormatters[$locale] = $formatter;
+        return new NumberFormatter($locale, $style ?? NumberFormatter::CURRENCY);
+    }
+
+    /**
+     * Create a number formatter for retrieving symbols.
+     *
+     * @param  string  $locale
+     * @param  string  $currencyCode
+     * @return NumberFormatter
+     */
+    protected function getSymbolFormatter(string $locale, string $currencyCode): NumberFormatter
+    {
+        return $this->getFormatter(
+            $this->getFormatterCacheKey(func_get_args()),
+            function () use ($locale, $currencyCode) {
+                return $this->getBaseFormatter(
+                    $this->getSystemLocale($locale) . "@currency=$currencyCode"
+                );
+            }
+        );
+    }
+
+    /**
+     * Create a number formatter with a given precision.
+     *
+     * @param  string  $locale
+     * @param  int|null  $precision
+     * @return NumberFormatter
+     */
+    protected function getFixedPrecisionFormatter(string $locale, ?int $precision): NumberFormatter
+    {
+        return $this->getFormatter(
+            $this->getFormatterCacheKey(func_get_args()),
+            function () use ($locale, $precision) {
+                $formatter = $this->getBaseFormatter($this->getSystemLocale($locale));
+
+                if (is_int($precision)) {
+                    $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $precision);
+                    $formatter->setAttribute(NumberFormatter::MIN_FRACTION_DIGITS, $precision);
+                }
+
+                return $formatter;
+            }
+        );
+    }
+
+    /**
+     * Create a number formatter using a pattern.
+     *
+     * @param  string  $locale
+     * @param  string  $pattern
+     * @return NumberFormatter
+     */
+    protected function getPatternedFormatter(string $locale, string $pattern): NumberFormatter
+    {
+        return $this->getFormatter(
+            $this->getFormatterCacheKey(func_get_args()),
+            function () use ($locale, $pattern) {
+                $formatter = $this->getBaseFormatter($this->getSystemLocale($locale));
+
+                $formatter->setPattern($pattern);
+
+                return $formatter;
+            }
+        );
     }
 }

--- a/src/Facades/CurrencyHelper.php
+++ b/src/Facades/CurrencyHelper.php
@@ -6,13 +6,11 @@ use Illuminate\Support\Facades\Facade;
 use PodPoint\I18n\CurrencyCode;
 
 /**
- * // phpcs:disable.
  * @method static string toFormat($value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  * @method static string toFormatFromInt(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  * @method static string toStandardFormat(float $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  * @method static string getFormatToMinorUnitWhenApplicable(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
  * @method static string getSymbol(string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en')
- * // phpcs:enable
  */
 class CurrencyHelper extends Facade
 {

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -16,7 +16,7 @@ abstract class Helper
     /**
      * CountryHelper constructor.
      *
-     * @param Repository $config
+     * @param  Repository  $config
      */
     public function __construct(Repository $config)
     {

--- a/src/LocalizedHelper.php
+++ b/src/LocalizedHelper.php
@@ -31,7 +31,7 @@ abstract class LocalizedHelper extends Helper
      *
      * @return string|null
      */
-    protected function getSystemLocale(string $locale, $fallback = true): ?string
+    protected function getSystemLocale(string $locale, bool $fallback = true): ?string
     {
         $country = $this->countryHelper->findByLocale($locale);
 

--- a/src/LocalizedHelper.php
+++ b/src/LocalizedHelper.php
@@ -14,7 +14,7 @@ abstract class LocalizedHelper extends Helper
     protected $countryHelper;
 
     /**
-     * @param Repository $config
+     * @param  Repository  $config
      */
     public function __construct(Repository $config)
     {
@@ -26,9 +26,8 @@ abstract class LocalizedHelper extends Helper
     /**
      * Return system locale from locale. (en => en_GB.UTF-8).
      *
-     * @param string $locale
-     * @param bool $fallback
-     *
+     * @param  string  $locale
+     * @param  bool  $fallback
      * @return string|null
      */
     protected function getSystemLocale(string $locale, bool $fallback = true): ?string
@@ -41,8 +40,7 @@ abstract class LocalizedHelper extends Helper
     /**
      * Return minor unit pattern from locale. (en => #.##p).
      *
-     * @param string $locale
-     *
+     * @param  string  $locale
      * @return string|null
      */
     protected function getMinorUnitPattern(string $locale): ?string
@@ -55,8 +53,7 @@ abstract class LocalizedHelper extends Helper
     /**
      * Return the last minor unit from locale. (en => 99).
      *
-     * @param string $locale
-     *
+     * @param  string  $locale
      * @return int|null
      */
     protected function getMinorUnitEnd(string $locale): ?int

--- a/src/NumberHelper.php
+++ b/src/NumberHelper.php
@@ -9,9 +9,8 @@ class NumberHelper extends LocalizedHelper
     /**
      * Return a number formatted for the given locale.
      *
-     * @param float|int $value
-     * @param string $locale
-     *
+     * @param  float|int  $value
+     * @param  string  $locale
      * @return string
      */
     public function toFormat($value, string $locale = 'en'): string

--- a/src/TaxRate.php
+++ b/src/TaxRate.php
@@ -19,8 +19,7 @@ class TaxRate
     /**
      * Returns the tax rate for the given country code.
      *
-     * @param string $countryCode
-     *
+     * @param  string  $countryCode
      * @return float
      */
     public function get(string $countryCode): float
@@ -32,12 +31,11 @@ class TaxRate
      * Calculate the VAT based on the net price, country code and indication if the
      * customer is a company or not.
      *
-     * @param int|float $netPrice The net price to use for the calculation
-     * @param string $countryCode The country code to use for the rate lookup
-     * @param string|null $postalCode The postal code to use for the rate exception lookup
-     * @param bool|null $company Whether or not the customer is a company
-     * @param string|null $type The type can be low or high
-     *
+     * @param  int|float  $netPrice  The net price to use for the calculation
+     * @param  string  $countryCode  The country code to use for the rate lookup
+     * @param  string|null  $postalCode  The postal code to use for the rate exception lookup
+     * @param  bool|null  $company  Whether or not the customer is a company
+     * @param  string|null  $type  The type can be low or high
      * @return float
      */
     public function calculate($netPrice, string $countryCode, ?string $postalCode = null, ?bool $company = null, ?string $type = null): float
@@ -49,12 +47,11 @@ class TaxRate
      * Calculate the net price on the gross price, country code and indication if the
      * customer is a company or not.
      *
-     * @param int|float $grossPrice The gross price to use for the calculation
-     * @param string $countryCode The country code to use for the rate lookup
-     * @param string|null $postalCode The postal code to use for the rate exception lookup
-     * @param bool|null $company Whether or not the customer is a company
-     * @param string|null $type The type can be low or high
-     *
+     * @param  int|float  $grossPrice  The gross price to use for the calculation
+     * @param  string  $countryCode  The country code to use for the rate lookup
+     * @param  string|null  $postalCode  The postal code to use for the rate exception lookup
+     * @param  bool|null  $company  Whether or not the customer is a company
+     * @param  string|null  $type  The type can be low or high
      * @return float
      */
     public function exclude($grossPrice, string $countryCode, ?string $postalCode = null, ?bool $company = null, ?string $type = null): float

--- a/src/ViewComposers/CountryCodeViewComposer.php
+++ b/src/ViewComposers/CountryCodeViewComposer.php
@@ -15,7 +15,7 @@ class CountryCodeViewComposer
     private $config;
 
     /**
-     * @param Repository $config
+     * @param  Repository  $config
      */
     public function __construct(Repository $config)
     {
@@ -25,7 +25,7 @@ class CountryCodeViewComposer
     /**
      * Binds the data to the view.
      *
-     * @param View $view
+     * @param  View  $view
      */
     public function compose(View $view)
     {
@@ -37,10 +37,9 @@ class CountryCodeViewComposer
     /**
      * Get a country choice.
      *
-     * @param string $countryCode
-     * @param array  $country
-     * @param bool   $defaultChoice
-     *
+     * @param  string  $countryCode
+     * @param  array  $country
+     * @param  bool  $defaultChoice
      * @return array
      */
     public function countryChoice(string $countryCode, array $country, bool $defaultChoice = false): array
@@ -57,9 +56,9 @@ class CountryCodeViewComposer
     /**
      * Get the country-code options by looping the countries in the config, while also adding the flag emojis.
      *
-     * @throws \InvalidArgumentException
-     *
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
     private function countryCodeOptions(): string
     {
@@ -98,11 +97,10 @@ class CountryCodeViewComposer
     /**
      * Get a country label.
      *
-     * @param string   $countryCode
-     * @param string   $countryName
-     * @param int|null $diallingCode
-     * @param bool     $defaultChoice
-     *
+     * @param  string  $countryCode
+     * @param  string  $countryName
+     * @param  int|null  $diallingCode
+     * @param  bool  $defaultChoice
      * @return string
      */
     private function countryLabel(string $countryCode, string $countryName, $diallingCode, bool $defaultChoice = false): string
@@ -117,9 +115,8 @@ class CountryCodeViewComposer
     /**
      * Get a country name markup.
      *
-     * @param string $name
-     * @param bool   $defaultChoice
-     *
+     * @param  string  $name
+     * @param  bool  $defaultChoice
      * @return string
      */
     private function countryNameMarkup(string $name, bool $defaultChoice = false): string
@@ -130,9 +127,8 @@ class CountryCodeViewComposer
     /**
      * Get a dialling code markup.
      *
-     * @param int|null $diallingCode
-     * @param bool     $defaultChoice
-     *
+     * @param  int|null  $diallingCode
+     * @param  bool  $defaultChoice
      * @return string
      */
     private function dialingCodeMarkup(?int $diallingCode = null, bool $defaultChoice = false): string
@@ -147,8 +143,7 @@ class CountryCodeViewComposer
     /**
      * Get the emoji flag for a given country code.
      *
-     * @param string $countryCode
-     *
+     * @param  string  $countryCode
      * @return string
      */
     private function emojiFlag(string $countryCode): string
@@ -165,8 +160,7 @@ class CountryCodeViewComposer
     /**
      * Get the unicode character for a given letter.
      *
-     * @param string $letter
-     *
+     * @param  string  $letter
      * @return string
      */
     private function unicodeCharacter(string $letter): string

--- a/src/ViewComposers/CountryLocaleViewComposer.php
+++ b/src/ViewComposers/CountryLocaleViewComposer.php
@@ -17,7 +17,7 @@ class CountryLocaleViewComposer
     /**
      * CountryLocaleViewComposer constructor.
      *
-     * @param Repository $config
+     * @param  Repository  $config
      */
     public function __construct(Repository $config)
     {
@@ -28,7 +28,7 @@ class CountryLocaleViewComposer
      * Fetches the supported application locales for Laravel and their "Display names" from the
      * enhanced configuration array and binds the data to the view.
      *
-     * @param View $view
+     * @param  View  $view
      *
      * @see \PodPoint\I18n\CountriesServiceProvider::addIsoInfoToCountryConfig()
      */

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -8,10 +8,9 @@ if (! function_exists('moneyFormat')) {
     /**
      * Return a value in the given currency formatted for the given locale.
      *
-     * @param float|int $value
-     * @param string $currencyCode
-     * @param string $locale
-     *
+     * @param  float|int  $value
+     * @param  string  $currencyCode
+     * @param  string  $locale
      * @return string
      */
     function moneyFormat($value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
@@ -26,10 +25,9 @@ if (! function_exists('moneyFormatFromInt')) {
      * Transform an integer representing a decimal currency value (penny, cents...) into a monetary formatted string
      * with the right currency symbol and the right localised format for the parameters respectively given.
      *
-     * @param int $value
-     * @param string $currencyCode
-     * @param string $locale
-     *
+     * @param  int  $value
+     * @param  string  $currencyCode
+     * @param  string  $locale
      * @return string
      */
     function moneyFormatFromInt(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
@@ -43,9 +41,8 @@ if (! function_exists('getCurrencySymbol')) {
     /**
      * Return a currency symbol formatted in the right locale.
      *
-     * @param string $currencyCode
-     * @param string $locale
-     *
+     * @param  string  $currencyCode
+     * @param  string  $locale
      * @return string
      */
     function getCurrencySymbol(string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string
@@ -59,10 +56,9 @@ if (! function_exists('getFormatToMinorUnitWhenApplicable')) {
     /**
      * Return a currency symbol formatted in the right locale.
      *
-     * @param int $value
-     * @param string $currencyCode
-     * @param string $locale
-     *
+     * @param  int  $value
+     * @param  string  $currencyCode
+     * @param  string  $locale
      * @return string
      */
     function getFormatToMinorUnitWhenApplicable(int $value, string $currencyCode = CurrencyCode::POUND_STERLING, string $locale = 'en'): string

--- a/tests/Unit/CurrencyHelperTest.php
+++ b/tests/Unit/CurrencyHelperTest.php
@@ -13,7 +13,7 @@ class CurrencyHelperTest extends TestCase
      *
      * @return array
      */
-    public function providerTestToFormat()
+    public function providerTestToFormat(): array
     {
         $value = 1500.5;
 
@@ -38,10 +38,10 @@ class CurrencyHelperTest extends TestCase
      *
      * @dataProvider providerTestToFormat
      *
-     * @param float $value
-     * @param string $currencyCode
-     * @param string $locale
-     * @param string $expected
+     * @param  float  $value
+     * @param  string  $currencyCode
+     * @param  string  $locale
+     * @param  string  $expected
      */
     public function testToFormat(float $value, string $currencyCode, string $locale, string $expected)
     {
@@ -61,9 +61,14 @@ class CurrencyHelperTest extends TestCase
      *
      * @return array
      */
-    public function providerTestGetSymbol()
+    public function providerTestGetSymbol(): array
     {
         return [
+            'Euro' => [
+                CurrencyCode::EURO,
+                'en',
+                '€',
+            ],
             'Pound Sterling' => [
                 CurrencyCode::POUND_STERLING,
                 'en',
@@ -82,7 +87,7 @@ class CurrencyHelperTest extends TestCase
      *
      * @return array
      */
-    public function providerTestFormatToMinorUnitWhenApplicable()
+    public function providerTestFormatToMinorUnitWhenApplicable(): array
     {
         return [
             'Pound Sterling happy path' => [
@@ -129,9 +134,9 @@ class CurrencyHelperTest extends TestCase
      *
      * @dataProvider providerTestGetSymbol
      *
-     * @param string $currencyCode
-     * @param string $locale
-     * @param string $expected
+     * @param  string  $currencyCode
+     * @param  string  $locale
+     * @param  string  $expected
      */
     public function testGetSymbol(string $currencyCode, string $locale, string $expected)
     {
@@ -232,11 +237,12 @@ class CurrencyHelperTest extends TestCase
     /**
      * Tests that it returns formatted value with minor unit symbol from fractional monetary values.
      *
-     * @dataProvider  providerTestFormatToMinorUnitWhenApplicable
-     * @param int $value
-     * @param string $currencyCode
-     * @param string $locale
-     * @param string $expected
+     * @dataProvider providerTestFormatToMinorUnitWhenApplicable
+     *
+     * @param  int  $value
+     * @param  string  $currencyCode
+     * @param  string  $locale
+     * @param  string  $expected
      */
     public function testFormatToMinorUnitWhenApplicable(int $value, string $currencyCode, string $locale, string $expected)
     {

--- a/tests/Unit/NumberHelperTest.php
+++ b/tests/Unit/NumberHelperTest.php
@@ -35,9 +35,9 @@ class NumberHelperTest extends TestCase
      *
      * @dataProvider providerTestToFormat
      *
-     * @param float $value
-     * @param string $locale
-     * @param string $expected
+     * @param  float  $value
+     * @param  string  $locale
+     * @param  string  $expected
      */
     public function testToFormat(float $value, string $locale, string $expected)
     {

--- a/tests/Unit/TaxRateTest.php
+++ b/tests/Unit/TaxRateTest.php
@@ -53,8 +53,8 @@ class TaxRateTest extends TestCase
      *
      * @dataProvider supportedCountriesTaxRateDataProvider
      *
-     * @param string $countryCode
-     * @param float $currentVatRate
+     * @param  string  $countryCode
+     * @param  float  $currentVatRate
      */
     public function testWeCanGetTaxRateForSupportedCountries(string $countryCode, float $currentVatRate)
     {
@@ -99,9 +99,9 @@ class TaxRateTest extends TestCase
      * Make sure we can calculate the price after tax (with VAT) based on a net price, before tax,
      * for a specific country. We only test the supported countries through a Data Provider.
      *
-     * @param string $countryCode
-     * @param float $netPrice
-     * @param float $vatPrice
+     * @param  string  $countryCode
+     * @param  float  $netPrice
+     * @param  float  $vatPrice
      *
      * @dataProvider supportedCountriesCalculationDataProvider
      */
@@ -140,9 +140,9 @@ class TaxRateTest extends TestCase
      * Make sure we can calculate the price before tax (excluding VAT) based on a gross price, after tax,
      * for a specific country. We only test the supported countries through a Data Provider.
      *
-     * @param string $countryCode
-     * @param float $grossPrice
-     * @param float $exVatPrice
+     * @param  string  $countryCode
+     * @param  float  $grossPrice
+     * @param  float  $exVatPrice
      *
      * @dataProvider supportedCountriesExclusionDataProvider
      */


### PR DESCRIPTION
## Description
### Fix memoization logic
Fixes the memoization logic in the `CurrencyHelper` class. The current method caches the formatters by locale and, since the method modifies the instances of the formatters, calls on some methods influence the result of others.
Check the screenshot below to see an example.

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/3891780/162213509-d1fbcc44-8be9-4267-bf07-2f84a03d5865.png">

The new logic calculates the cache key from some of the method's parameters and the method's name.

### Fix getSymbol
Fixes the `getSymbol` method, broken [here](https://github.com/Pod-Point/countries/commit/44f01361927577d7dc0315c1510530d055c3fad9#diff-4c656219057e4f6c3360cb7546356169361c43314094c64b0a058f2cec68b78bR98).