### PR TITLE
fix(v5): locale for Ireland

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:

--- a/config/countries-partial.php
+++ b/config/countries-partial.php
@@ -28,7 +28,7 @@ return [
     ],
     CountryCode::IRELAND => [
         'systemLocale' => 'en_IE.UTF-8',
-        'locale' => 'ie',
+        'locale' => 'en',
         'language' => 'ENG',
         'tld' => 'ie',
         'timezone' => 'Europe/Dublin',


### PR DESCRIPTION
They speak English in Ireland. I think.

We should use `{locale/language}_{country_code_alpha2}`

- English (United Kingdom): `en_GB`
- English (Ireland): `en_IE`
- Norwegian (Norway): `no_NO`

`ie_IE` doesn't exist.

Source: https://saimana.com/list-of-country-locale-code/