### PR TITLE
fix(v4): revert locale for Ireland

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: true
       matrix:

--- a/config/countries-partial.php
+++ b/config/countries-partial.php
@@ -28,7 +28,7 @@ return [
     ],
     CountryCode::IRELAND => [
         'systemLocale' => 'en_IE.UTF-8',
-        'locale' => 'en',
+        'locale' => 'ie',
         'language' => 'ENG',
         'tld' => 'ie',
         'timezone' => 'Europe/Dublin',


### PR DESCRIPTION
Revert #66 as this has a knock on effect on API3 and the mobile app using `ie` wrongly as a locale instead of `en_IE`.